### PR TITLE
fix: rollup build exception

### DIFF
--- a/api/setup.js
+++ b/api/setup.js
@@ -1,3 +1,4 @@
+// @ts-ignore
 import {ZkWasmUtil} from "zkwasm-service-helper";
 import {
     logLoadingAnimation

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,8 @@
 import { builtinModules } from 'node:module'
 import path from 'node:path'
 import esbuild from 'rollup-plugin-esbuild'
-import { dts } from 'rollup-plugin-dts'
-import nodeResolve from '@rollup/plugin-node-resolve'
+// import { dts } from 'rollup-plugin-dts'
+// import nodeResolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import { defineConfig } from 'rollup'
@@ -11,16 +11,22 @@ const input = path.join(__dirname, './index.js')
 
 const external = [
   ...builtinModules,
+  'ethers',
+  'bn.js',
+  'js-yaml',
+  'zkwasm-service-helper',
+  'web3-eth-contract',
+  'semver',
+  'axios',
+  'form-data',
+  '@ethereumjs/rlp'
 ]
-
-
-console.log(esbuild.default)
 
 const plugins = [
   json(),
-  nodeResolve({
-    preferBuiltins: true,
-  }),
+  // nodeResolve({
+  //   preferBuiltins: true,
+  // }),
   commonjs(),
   esbuild.default({
     target: 'node14',


### PR DESCRIPTION
Pure build: remove `node resolve` plugin and `external` includes all dependencies.